### PR TITLE
Code-only Notification Center support.

### DIFF
--- a/Classes/GSNotifier.m
+++ b/Classes/GSNotifier.m
@@ -37,9 +37,6 @@ static NSString *_lastMessage = nil;
 
 + (void)showGPUChangeNotification:(GSGPUType)type
 {
-    // FIXME: Support Mountain Lion's Notification Center here in addition to
-    // Growl on supported (>= 10.8.x) machines.
-    
     // Get the localized notification name and message, as well as the current
     // GPU name for display in the message.
     NSString *key = [self _keyForNotificationType:type];
@@ -52,13 +49,22 @@ static NSString *_lastMessage = nil;
     // check to make sure the user even wants to see the notifications in the
     // first place.
     if (![message isEqualToString:_lastMessage] && [GSPreferences sharedInstance].shouldDisplayNotifications) {
-        [GrowlApplicationBridge notifyWithTitle:title
-                                    description:message 
-                               notificationName:key
-                                       iconData:nil 
-                                       priority:0 
-                                       isSticky:NO 
-                                   clickContext:nil];
+        if (NSClassFromString(@"NSUserNotification")) {
+            NSUserNotification *notification = [NSUserNotification new];
+            notification.deliveryDate = [NSDate date];
+            notification.hasActionButton = NO;
+            notification.title = title;
+            notification.informativeText = message;
+            [[NSUserNotificationCenter defaultUserNotificationCenter] scheduleNotification: notification];
+        } else {
+            [GrowlApplicationBridge notifyWithTitle:title
+                                        description:message
+                                   notificationName:key
+                                           iconData:nil
+                                           priority:0
+                                           isSticky:NO
+                                       clickContext:nil];
+        }
         
         _lastMessage = message;
     }

--- a/Classes/gfxCardStatusAppDelegate.m
+++ b/Classes/gfxCardStatusAppDelegate.m
@@ -73,7 +73,8 @@
     
     // Set up Growl notifications regardless of whether or not we're supposed
     // to Growl.
-    [GrowlApplicationBridge setGrowlDelegate:[GSNotifier sharedInstance]];
+    if (!NSClassFromString(@"NSUserNotification"))
+        [GrowlApplicationBridge setGrowlDelegate:[GSNotifier sharedInstance]];
     
     // Hook up the check for updates on startup preference directly to the
     // automaticallyChecksForUpdates property on the SUUpdater.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ with dual GPUs to monitor the status of, and switch between said GPUs.
 - allows locking the system on one GPU or the other, or allowing automatic switching
 - does not require you to log out or restart to switch GPUs - it's all done on the fly!
 - allows you to see which GPU is in use at a glance in the menu bar - "i" for integrated, "d" for discrete
-- Growl support ensures that you know exactly when the GPU changes, provided you have Growl installed
+- Notifications ensure that you know exactly when the GPU changes, provided you have Growl installed or OS X 10.8
 - light, fast, and minimalist. doesn't get in your way, and uses little to no system resources
 
 Feature requests/bug reports are always welcome by email: cody [at] codykrieger [dot] com


### PR DESCRIPTION
Hey, here's a scratch-my-own-OCD-itch patch to add Notification Center support. It depends on the 10.8 SDK (as does the rest of the codebase), but will continue to run against Growl on 10.7. Growl support (by way of the application bridge) is never initialized if running on 10.8.

There are a couple of things that would need to be changed to constitute "full" support, in addition to this patch. The preferences text could be changed simply to read "Display GPU change notifications". I tried, but I don't understand that many languages, sorry. Removing the checkbox on 10.8 entirely is an option as well, since the Notifications pane in System Preferences is far more intuitive than the respective Growl panel, and might be better than even the Preference window. Ideally for code cleanliness, Growl references in the code could be factored out entirely, though that might cause some problems with the preference file.

Cheers!
