### PR TITLE
Fixed issue where 2010 MBPs switch to Discrete Only after apps quit

### DIFF
--- a/Classes/GSGPU.m
+++ b/Classes/GSGPU.m
@@ -64,7 +64,14 @@ static void _displayReconfigurationCallback(CGDirectDisplayID display, CGDisplay
             BOOL isUsingIntegrated = [GSMux isUsingIntegratedGPU];
             
             GTMLoggerInfo(@"Notification: GPU changed. Integrated? %d", isUsingIntegrated);
-            
+
+            // For Macbook Pro 2010 users who have set the mode to Integrated Only,
+            // there will be rogue apps like Chrome that switch the graphics to
+            // Discrete Only upon closing. This will reverse the switch
+            if (!isUsingIntegrated && ([GSMux currentGSSwitcherMode]==GSSwitcherModeForceIntegrated)) {
+                [GSMux setMode:GSSwitcherModeForceIntegrated];
+            }
+
             GSGPUType activeType = (isUsingIntegrated ? GSGPUTypeIntegrated : GSGPUTypeDiscrete);
             [_delegate GPUDidChangeTo:activeType];
         });

--- a/Classes/GSMux.h
+++ b/Classes/GSMux.h
@@ -34,4 +34,7 @@ typedef enum {
 + (BOOL)isOnIntegratedOnlyMode;
 + (BOOL)isOnDiscreteOnlyMode;
 
+// Returns the value of the current GSSwitcherMode as set in the Menu
++ (GSSwitcherMode) currentGSSwitcherMode;
+
 @end

--- a/Classes/GSMux.m
+++ b/Classes/GSMux.m
@@ -239,6 +239,13 @@ static void dumpState(io_connect_t connect)
 
 @implementation GSMux
 
+static GSSwitcherMode currentGSSwitcherMode;
+
++(GSSwitcherMode)currentGSSwitcherMode
+{
+    return currentGSSwitcherMode;
+}
+
 #pragma mark - GSMux API
 #pragma mark Initialization/destruction
 
@@ -303,10 +310,14 @@ static void dumpState(io_connect_t connect)
 {
     if (_switcherConnect == IO_OBJECT_NULL)
         return NO;
-    
+
+    // Set current GSSwitcher mode
+    currentGSSwitcherMode = mode;
+
     switch (mode) {
         case GSSwitcherModeForceIntegrated:
         case GSSwitcherModeForceDiscrete:
+
             // Disable dynamic switching
             setDynamicSwitchingEnabled(_switcherConnect, NO);
             


### PR DESCRIPTION
Hi Cody,

I'm a 2010 MBP user. I have been a fan of your app for a long time, using it to force the Integrated Only mode. The problem is that the mode will change to Discrete Only after certain apps which use Core Graphics close, such as Chrome or iOS Simulator.

The few lines of code I've added in fixes this problem:
- Created a static variable in GSMux to note which mode the user has selected
- In the displayConfigurationCallback section in GSGPU.m, if the user has selected Integrated Only but the discrete graphics is on, there will be a call to [GSMux setMode:] to change it back to Integrated Only.
- Do note that forceSwitch doesn't help in this case, since it resolves any discrepancy to the system mode, while my solution resolves it to the user's preference, which is how it should be.

Btw, I have also read that you have selected Dynamic Switching to default upon login so that the app runs smoothly. I think a better solution would be to first select Dynamic Switching to ensure the smoothness, then change it immediately afterwards to the user's last selected preference. What do you think?
