### PR TITLE
Modified GSMenuController.m to ignore dependencies when switching to Int...

### DIFF
--- a/Classes/GSMenuController.m
+++ b/Classes/GSMenuController.m
@@ -196,7 +196,7 @@
 
     if (sender == integratedOnly) {
         NSArray *taskList = [GSProcess getTaskList];
-        if (taskList.count > 0) {
+        /*if (taskList.count > 0) {
             GTMLoggerInfo(@"Not setting Integrated Only because of dependencies list items: %@", taskList);
 
             NSMutableArray *taskNames = [[NSMutableArray alloc] init];
@@ -207,7 +207,7 @@
 
             [GSNotifier showCantSwitchToIntegratedOnlyMessage:taskNames];
             return;
-        }
+        }*/
 
         GTMLoggerInfo(@"Setting Integrated Only...");
         retval = [GSMux setMode:GSSwitcherModeForceIntegrated];

--- a/Classes/GSProcess.m
+++ b/Classes/GSProcess.m
@@ -168,7 +168,7 @@ static void _procScan(io_registry_entry_t service, NSMutableArray *arr) {
     // scan the kernel process list for discrete gpu-using tasks
     io_registry_entry_t service = 0;
     service = IORegistryGetRootEntry(kIOMasterPortDefault);
-    if (!service)
+    if (!service) ////COMMENT THIS TO DISABLE DISCRETE_LOCK
         return [NSArray array];
     
     _procUpdate();


### PR DESCRIPTION
...egrated graphics.

Essentially, I like to use gfxCardStatus to have control over my graphics cards, regardless of power consumption. I can use it to directly test graphical quality between the two cards, so if a dependency is listed it inhibits this ability. I have modified the source to allow for immediate switching. 
Zero bugs reported. 
