### PR TITLE
Fix the menu state on the 2016 MacBook Pro when Integrated Only is enabled. On these Macs, +[GSMux isUsingOldStyleSwitchPolicy] always returns false, which means that, if the system is set to run in Integrated Only mode, then the discrete GPU will be incorrectly checked off in the status item’s menu. But checking to see if dynamic switching is turned off works as expected.

### DIFF
--- a/Classes/GSMux.m
+++ b/Classes/GSMux.m
@@ -374,12 +374,12 @@ static void dumpState(io_connect_t connect)
 
 + (BOOL)isOnIntegratedOnlyMode
 {
-    return [self isUsingIntegratedGPU] && ([self isUsingOldStyleSwitchPolicy] || [GSGPU is2010MacBookPro]);
+	return [self isUsingIntegratedGPU] && ![self isUsingDynamicSwitching];
 }
 
 + (BOOL)isOnDiscreteOnlyMode
 {
-    return [self isUsingDiscreteGPU] && ([self isUsingOldStyleSwitchPolicy] || [GSGPU is2010MacBookPro]);
+	return [self isUsingDiscreteGPU] && ![self isUsingDynamicSwitching];
 }
 
 @end


### PR DESCRIPTION
Will this cause problems on older MBPs? I doubt it, but would you be able to test that?