### PR TITLE
Quick fix menubar icon offset in macOS Big Sur

### DIFF
--- a/Classes/GSMenuController.m
+++ b/Classes/GSMenuController.m
@@ -327,9 +327,21 @@
                                               weight:0
                                                 size:fontSize];
 
+    // Quick fix for menubar icon offset in macOS Big Sur
+    double baselineOffset = 2.0;
+    NSProcessInfo* processInfo = [NSProcessInfo processInfo];
+    
+    if ([processInfo respondsToSelector:@selector(operatingSystemVersion)]) {
+        NSOperatingSystemVersion systemVersion = [processInfo operatingSystemVersion];
+        // 10.16 is for backward compatibility targeting 10.x SDK
+        if (systemVersion.majorVersion >= 11 || (systemVersion.majorVersion >= 10 && systemVersion.minorVersion >= 16)) {
+            baselineOffset = -1.0;
+        }
+    }
+    
     NSDictionary *attributes = [[NSDictionary alloc] initWithObjectsAndKeys:
-                                boldItalic, NSFontAttributeName, 
-                                [NSNumber numberWithDouble:2.0], NSBaselineOffsetAttributeName, nil];
+                                boldItalic, NSFontAttributeName,
+                                [NSNumber numberWithDouble:baselineOffset], NSBaselineOffsetAttributeName, nil];
     NSAttributedString *title = [[NSAttributedString alloc] 
                                  initWithString:letter
                                  attributes:attributes];

--- a/Classes/GSMenuController.m
+++ b/Classes/GSMenuController.m
@@ -331,6 +331,7 @@
     double baselineOffset = 2.0;
     NSProcessInfo* processInfo = [NSProcessInfo processInfo];
     
+    // [NSProcessInfo operatingSystemVersion] is only available since macOS 10.10
     if ([processInfo respondsToSelector:@selector(operatingSystemVersion)]) {
         NSOperatingSystemVersion systemVersion = [processInfo operatingSystemVersion];
         // 10.16 is for backward compatibility targeting 10.x SDK


### PR DESCRIPTION
Tested working in macOS 11.0.1 and 10.15.6. Not sure if earlier ones are well supported.

<img width="733" alt="macOS 11.0.1" src="https://user-images.githubusercontent.com/1834970/99048560-9276d100-254a-11eb-8985-2c27c7c18494.png">

![macOS 10.15.6](https://user-images.githubusercontent.com/1834970/99049451-b5ee4b80-254b-11eb-9df3-5bc992681d78.jpg)